### PR TITLE
feat: add support for custom scrcpy binary path

### DIFF
--- a/library/src/main/kotlin/jp/kaleidot725/scrcpykt/ScrcpyClient.kt
+++ b/library/src/main/kotlin/jp/kaleidot725/scrcpykt/ScrcpyClient.kt
@@ -4,7 +4,9 @@ import jp.kaleidot725.scrcpykt.builder.ScrcpyCommandBuilder
 import jp.kaleidot725.scrcpykt.option.VideoSource
 import java.io.IOException
 
-class ScrcpyClient {
+class ScrcpyClient(
+    private val binaryPath: String = "scrcpy"
+) {
     fun execute(
         command: ScrcpyCommand,
         isRecording: Boolean = false,
@@ -12,8 +14,8 @@ class ScrcpyClient {
         return try {
             // Validate scrcpy executable exists
             val commandList = command.buildCommand()
-            if (commandList.isEmpty() || commandList[0] != "scrcpy") {
-                return ScrcpyResult.Error("Invalid scrcpy command", IllegalArgumentException("Command must start with 'scrcpy'"))
+            if (commandList.isEmpty()) {
+                return ScrcpyResult.Error("Invalid scrcpy command", IllegalArgumentException("Command cannot be empty"))
             }
 
             val processBuilder = ProcessBuilder(commandList)
@@ -33,7 +35,8 @@ class ScrcpyClient {
         }
     }
 
-    fun command(configure: ScrcpyCommandBuilder.() -> Unit): ScrcpyCommand = ScrcpyCommandBuilder().apply(configure).build()
+    fun command(configure: ScrcpyCommandBuilder.() -> Unit): ScrcpyCommand = 
+        ScrcpyCommandBuilder(binaryPath).apply(configure).build()
 
     fun mirror(configure: ScrcpyCommandBuilder.() -> Unit = {}): ScrcpyResult {
         val command = command(configure)
@@ -75,6 +78,8 @@ class ScrcpyClient {
 
     companion object {
         fun create(): ScrcpyClient = ScrcpyClient()
+        
+        fun create(binaryPath: String): ScrcpyClient = ScrcpyClient(binaryPath)
     }
 }
 

--- a/library/src/main/kotlin/jp/kaleidot725/scrcpykt/ScrcpyCommand.kt
+++ b/library/src/main/kotlin/jp/kaleidot725/scrcpykt/ScrcpyCommand.kt
@@ -13,6 +13,8 @@ import jp.kaleidot725.scrcpykt.option.VideoCodec
 import jp.kaleidot725.scrcpykt.option.VideoSource
 
 data class ScrcpyCommand(
+    // Binary path
+    var binaryPath: String = "scrcpy",
     // Video options
     var videoBitRate: Int? = null,
     var maxFps: Int? = null,
@@ -71,7 +73,7 @@ data class ScrcpyCommand(
     var startApp: String? = null,
 ) {
     fun buildCommand(): List<String> {
-        val command = mutableListOf("scrcpy")
+        val command = mutableListOf(binaryPath)
 
         videoBitRate?.let { command.addAll(listOf("--video-bit-rate", it.toString())) }
         maxFps?.let { command.addAll(listOf("--max-fps", it.toString())) }

--- a/library/src/main/kotlin/jp/kaleidot725/scrcpykt/builder/ScrcpyCommandBuilder.kt
+++ b/library/src/main/kotlin/jp/kaleidot725/scrcpykt/builder/ScrcpyCommandBuilder.kt
@@ -3,8 +3,8 @@ package jp.kaleidot725.scrcpykt.builder
 import jp.kaleidot725.scrcpykt.ScrcpyCommand
 import jp.kaleidot725.scrcpykt.option.LogLevel
 
-class ScrcpyCommandBuilder {
-    private val command = ScrcpyCommand()
+class ScrcpyCommandBuilder(private val binaryPath: String = "scrcpy") {
+    private val command = ScrcpyCommand(binaryPath = binaryPath)
 
     fun video(configure: VideoOptionsBuilder.() -> Unit) =
         apply {

--- a/library/src/test/kotlin/jp/kaleidot725/scrcpykt/ScrcpyClientTest.kt
+++ b/library/src/test/kotlin/jp/kaleidot725/scrcpykt/ScrcpyClientTest.kt
@@ -1,0 +1,47 @@
+package jp.kaleidot725.scrcpykt
+
+import jp.kaleidot725.scrcpykt.builder.ScrcpyCommandBuilder
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ScrcpyClientTest {
+    @Test
+    fun `ScrcpyClient should use default binary path`() {
+        val client = ScrcpyClient.create()
+        val command = client.command { }
+        val commandList = command.buildCommand()
+        
+        assertEquals("scrcpy", commandList[0])
+    }
+
+    @Test
+    fun `ScrcpyClient should use custom binary path`() {
+        val customPath = "/custom/path/to/scrcpy"
+        val client = ScrcpyClient.create(customPath)
+        val command = client.command { }
+        val commandList = command.buildCommand()
+        
+        assertEquals(customPath, commandList[0])
+    }
+
+    @Test
+    fun `ScrcpyClient constructor should accept binary path`() {
+        val customPath = "/another/path/to/scrcpy"
+        val client = ScrcpyClient(customPath)
+        val command = client.command { }
+        val commandList = command.buildCommand()
+        
+        assertEquals(customPath, commandList[0])
+    }
+
+    @Test
+    fun `ScrcpyCommandBuilder should use custom binary path`() {
+        val customPath = "/builder/path/to/scrcpy"
+        val builder = ScrcpyCommandBuilder(customPath)
+        val command = builder.build()
+        val commandList = command.buildCommand()
+        
+        assertEquals(customPath, commandList[0])
+    }
+}

--- a/library/src/test/kotlin/jp/kaleidot725/scrcpykt/ScrcpyCommandTest.kt
+++ b/library/src/test/kotlin/jp/kaleidot725/scrcpykt/ScrcpyCommandTest.kt
@@ -19,6 +19,14 @@ class ScrcpyCommandTest {
     }
 
     @Test
+    fun `buildCommand should use custom binary path`() {
+        val command = ScrcpyCommand(binaryPath = "/custom/path/to/scrcpy")
+        val result = command.buildCommand()
+
+        assertEquals("/custom/path/to/scrcpy", result[0])
+    }
+
+    @Test
     fun `buildCommand should include video options`() {
         val command =
             ScrcpyCommand(


### PR DESCRIPTION
## Summary
- Add support for specifying custom scrcpy binary path in ScrcpyClient
- Allow users to use non-default scrcpy executable locations
- Maintain backward compatibility with existing code

## Changes
- Added `binaryPath` parameter to ScrcpyClient constructor with default value "scrcpy"
- Added `binaryPath` field to ScrcpyCommand data class
- Updated ScrcpyCommandBuilder to accept and use custom binary path
- Added factory method `ScrcpyClient.create(binaryPath)` for convenience
- Added comprehensive tests for binary path functionality
- Updated validation logic to be more flexible with executable paths

## Test plan
- [x] All existing tests pass
- [x] New tests for custom binary path functionality
- [x] Backward compatibility verified
- [x] Default behavior unchanged

## Usage Examples
```kotlin
// Default usage (unchanged)
val client = ScrcpyClient.create()

// Custom binary path using constructor
val client = ScrcpyClient("/usr/local/bin/scrcpy")

// Custom binary path using factory method
val client = ScrcpyClient.create("/path/to/custom/scrcpy")
```

🤖 Generated with [Claude Code](https://claude.ai/code)