### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.github.kaleidot725"
-version = "1.7.0"
+version = "1.8.0"
 
 dependencies {
     testImplementation(kotlin("test"))


### PR DESCRIPTION
## Summary

Bump library version from 1.7.0 to 1.8.0.

• Updated version in library/build.gradle.kts

## Test plan

- [x] Version number updated correctly
- [x] Ready for release

🤖 Generated with [Claude Code](https://claude.ai/code)